### PR TITLE
Update homebrew formula to use python@3.11

### DIFF
--- a/aarch64-unknown-linux-gnu.rb
+++ b/aarch64-unknown-linux-gnu.rb
@@ -7,7 +7,7 @@ class Aarch64UnknownLinuxGnu < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v11.2.0/aarch64-unknown-linux-gnu-aarch64-darwin.tar.gz"

--- a/aarch64-unknown-linux-musl.rb
+++ b/aarch64-unknown-linux-musl.rb
@@ -7,7 +7,7 @@ class Aarch64UnknownLinuxMusl < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v11.2.0/aarch64-unknown-linux-musl-aarch64-darwin.tar.gz"

--- a/arm-unknown-linux-gnueabi.rb
+++ b/arm-unknown-linux-gnueabi.rb
@@ -7,7 +7,7 @@ class ArmUnknownLinuxGnueabi < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v11.2.0/arm-unknown-linux-gnueabi-aarch64-darwin.tar.gz"

--- a/arm-unknown-linux-gnueabihf.rb
+++ b/arm-unknown-linux-gnueabihf.rb
@@ -7,7 +7,7 @@ class ArmUnknownLinuxGnueabihf < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v11.2.0/arm-unknown-linux-gnueabihf-aarch64-darwin.tar.gz"

--- a/armv7-unknown-linux-gnueabihf.rb
+++ b/armv7-unknown-linux-gnueabihf.rb
@@ -7,7 +7,7 @@ class Armv7UnknownLinuxGnueabihf < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v11.2.0/armv7-unknown-linux-gnueabihf-aarch64-darwin.tar.gz"

--- a/armv7-unknown-linux-musleabihf.rb
+++ b/armv7-unknown-linux-musleabihf.rb
@@ -7,7 +7,7 @@ class Armv7UnknownLinuxMusleabihf < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v11.2.0/armv7-unknown-linux-musleabihf-aarch64-darwin.tar.gz"

--- a/i686-unknown-linux-gnu.rb
+++ b/i686-unknown-linux-gnu.rb
@@ -7,7 +7,7 @@ class I686UnknownLinuxGnu < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v11.2.0/i686-unknown-linux-gnu-aarch64-darwin.tar.gz"

--- a/i686-unknown-linux-musl.rb
+++ b/i686-unknown-linux-musl.rb
@@ -7,7 +7,7 @@ class I686UnknownLinuxMusl < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v11.2.0/i686-unknown-linux-musl-aarch64-darwin.tar.gz"

--- a/x86_64-unknown-linux-gnu.rb
+++ b/x86_64-unknown-linux-gnu.rb
@@ -7,7 +7,7 @@ class X8664UnknownLinuxGnu < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v11.2.0/x86_64-unknown-linux-gnu-aarch64-darwin.tar.gz"

--- a/x86_64-unknown-linux-musl.rb
+++ b/x86_64-unknown-linux-musl.rb
@@ -7,7 +7,7 @@ class X8664UnknownLinuxMusl < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v11.2.0/x86_64-unknown-linux-musl-aarch64-darwin.tar.gz"


### PR DESCRIPTION
Since `python@3.11` is now the default when the formula aliases `python`, `python3` or `python@3` are used:
https://formulae.brew.sh/formula/python@3.11

As such, many other formulae are already depending upon `python@3.11`, so switching to it for this project reduces the chance users will end up needing to have two different Python versions installed.