### PR TITLE
Update homebrew formula to depend on python@3.12

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           brew install coreutils crosstool-ng
           # fix python env in the runner
-          brew unlink python@3.11 && brew link --overwrite python@3.11
+          brew unlink python@3.12 && brew link --overwrite python@3.12
           python3 --version
       - name: Mount volumes
         run: |

--- a/aarch64-unknown-linux-gnu.rb
+++ b/aarch64-unknown-linux-gnu.rb
@@ -7,7 +7,7 @@ class Aarch64UnknownLinuxGnu < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.2.0/aarch64-unknown-linux-gnu-aarch64-darwin.tar.gz"

--- a/aarch64-unknown-linux-musl.rb
+++ b/aarch64-unknown-linux-musl.rb
@@ -7,7 +7,7 @@ class Aarch64UnknownLinuxMusl < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.2.0/aarch64-unknown-linux-musl-aarch64-darwin.tar.gz"

--- a/arm-unknown-linux-gnueabi.rb
+++ b/arm-unknown-linux-gnueabi.rb
@@ -7,7 +7,7 @@ class ArmUnknownLinuxGnueabi < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.2.0/arm-unknown-linux-gnueabi-aarch64-darwin.tar.gz"

--- a/arm-unknown-linux-gnueabihf.rb
+++ b/arm-unknown-linux-gnueabihf.rb
@@ -7,7 +7,7 @@ class ArmUnknownLinuxGnueabihf < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.2.0/arm-unknown-linux-gnueabihf-aarch64-darwin.tar.gz"

--- a/arm-unknown-linux-musleabihf.rb
+++ b/arm-unknown-linux-musleabihf.rb
@@ -7,7 +7,7 @@ class ArmUnknownLinuxMusleabihf < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.2.0/arm-unknown-linux-musleabihf-aarch64-darwin.tar.gz"

--- a/armv7-unknown-linux-gnueabihf.rb
+++ b/armv7-unknown-linux-gnueabihf.rb
@@ -7,7 +7,7 @@ class Armv7UnknownLinuxGnueabihf < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.2.0/armv7-unknown-linux-gnueabihf-aarch64-darwin.tar.gz"

--- a/armv7-unknown-linux-musleabihf.rb
+++ b/armv7-unknown-linux-musleabihf.rb
@@ -7,7 +7,7 @@ class Armv7UnknownLinuxMusleabihf < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.2.0/armv7-unknown-linux-musleabihf-aarch64-darwin.tar.gz"

--- a/i686-unknown-linux-gnu.rb
+++ b/i686-unknown-linux-gnu.rb
@@ -7,7 +7,7 @@ class I686UnknownLinuxGnu < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.2.0/i686-unknown-linux-gnu-aarch64-darwin.tar.gz"

--- a/i686-unknown-linux-musl.rb
+++ b/i686-unknown-linux-musl.rb
@@ -7,7 +7,7 @@ class I686UnknownLinuxMusl < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.2.0/i686-unknown-linux-musl-aarch64-darwin.tar.gz"

--- a/mipsel-unknown-linux-gnu.rb
+++ b/mipsel-unknown-linux-gnu.rb
@@ -9,11 +9,11 @@ class MipselUnknownLinuxGnu < Formula
   depends_on "zstd"
 
   if Hardware::CPU.arm?
-    depends_on "python@3.11"
+    depends_on "python@3.12"
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.2.0/mipsel-unknown-linux-gnu-aarch64-darwin.tar.gz"
     sha256 "b4e521bb7c28ed2b66f94f6a1bb6e840066fcbe1e4efde01528921cda3a07e99"
   else
-    depends_on "python@3.11"
+    depends_on "python@3.12"
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.2.0/mipsel-unknown-linux-gnu-x86_64-darwin.tar.gz"
     sha256 "5585d3890d5b978f67e39812203667b1ddf1719ff3e0b6ce06d9bdce8e7a0903"
   end

--- a/x86_64-unknown-linux-gnu.rb
+++ b/x86_64-unknown-linux-gnu.rb
@@ -7,7 +7,7 @@ class X8664UnknownLinuxGnu < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.2.0/x86_64-unknown-linux-gnu-aarch64-darwin.tar.gz"

--- a/x86_64-unknown-linux-musl.rb
+++ b/x86_64-unknown-linux-musl.rb
@@ -7,7 +7,7 @@ class X8664UnknownLinuxMusl < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.2.0/x86_64-unknown-linux-musl-aarch64-darwin.tar.gz"


### PR DESCRIPTION
Since `python@3.12` is now the default when the formula aliases `python` or `python3` are used:
https://formulae.brew.sh/formula/python@3.12

As such, many other formulae are already using `python@3.12`, so updating to it for this project reduces the chance users will end up having to have two different Python versions installed.

Given that now:
1. `crosstool-ng` has already updated it's own `depends_on` to `python@3.12`: https://github.com/Homebrew/homebrew-core/blob/46db7ec181fbe0857089cadaff91ab1373577bdb/Formula/c/crosstool-ng.rb#L36
2. The Python command alias has been set to `python3` via `CT_GDB_CROSS_PYTHON_BINARY` in the various `.config`s: https://github.com/search?q=repo%3Amessense%2Fhomebrew-macos-cross-toolchains%20CT_GDB_CROSS_PYTHON_BINARY&type=code

...I'm hopeful this should be more successful than when I attempted a Python version bump to 3.11 in #20 :-)