### PR TITLE
Update Python dependency to `python@3.13`

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -47,7 +47,7 @@ jobs:
           brew install coreutils
           brew install --HEAD crosstool-ng
           # fix python env in the runner
-          brew unlink python@3.12 && brew link --overwrite python@3.12
+          brew unlink python@3.13 && brew link --overwrite python@3.13
           python3 --version
       - name: Mount volumes
         run: |

--- a/aarch64-unknown-linux-gnu.rb
+++ b/aarch64-unknown-linux-gnu.rb
@@ -7,7 +7,7 @@ class Aarch64UnknownLinuxGnu < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.3.0/aarch64-unknown-linux-gnu-aarch64-darwin.tar.gz"

--- a/aarch64-unknown-linux-musl.rb
+++ b/aarch64-unknown-linux-musl.rb
@@ -7,7 +7,7 @@ class Aarch64UnknownLinuxMusl < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.3.0/aarch64-unknown-linux-musl-aarch64-darwin.tar.gz"

--- a/arm-unknown-linux-gnueabi.rb
+++ b/arm-unknown-linux-gnueabi.rb
@@ -7,7 +7,7 @@ class ArmUnknownLinuxGnueabi < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.3.0/arm-unknown-linux-gnueabi-aarch64-darwin.tar.gz"

--- a/arm-unknown-linux-gnueabihf.rb
+++ b/arm-unknown-linux-gnueabihf.rb
@@ -7,7 +7,7 @@ class ArmUnknownLinuxGnueabihf < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.3.0/arm-unknown-linux-gnueabihf-aarch64-darwin.tar.gz"

--- a/arm-unknown-linux-musleabihf.rb
+++ b/arm-unknown-linux-musleabihf.rb
@@ -7,7 +7,7 @@ class ArmUnknownLinuxMusleabihf < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.3.0/arm-unknown-linux-musleabihf-aarch64-darwin.tar.gz"

--- a/armv7-unknown-linux-gnueabihf.rb
+++ b/armv7-unknown-linux-gnueabihf.rb
@@ -7,7 +7,7 @@ class Armv7UnknownLinuxGnueabihf < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.3.0/armv7-unknown-linux-gnueabihf-aarch64-darwin.tar.gz"

--- a/armv7-unknown-linux-musleabihf.rb
+++ b/armv7-unknown-linux-musleabihf.rb
@@ -7,7 +7,7 @@ class Armv7UnknownLinuxMusleabihf < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.3.0/armv7-unknown-linux-musleabihf-aarch64-darwin.tar.gz"

--- a/formula.rb.j2
+++ b/formula.rb.j2
@@ -7,7 +7,7 @@ class {{ name }} < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v{{ version }}/{{ aarch64_artifact_name }}"

--- a/i686-unknown-linux-gnu.rb
+++ b/i686-unknown-linux-gnu.rb
@@ -7,7 +7,7 @@ class I686UnknownLinuxGnu < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.3.0/i686-unknown-linux-gnu-aarch64-darwin.tar.gz"

--- a/i686-unknown-linux-musl.rb
+++ b/i686-unknown-linux-musl.rb
@@ -7,7 +7,7 @@ class I686UnknownLinuxMusl < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.3.0/i686-unknown-linux-musl-aarch64-darwin.tar.gz"

--- a/mipsel-unknown-linux-gnu.rb
+++ b/mipsel-unknown-linux-gnu.rb
@@ -7,7 +7,7 @@ class MipselUnknownLinuxGnu < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.3.0/mipsel-unknown-linux-gnu-aarch64-darwin.tar.gz"

--- a/x86_64-unknown-linux-gnu.rb
+++ b/x86_64-unknown-linux-gnu.rb
@@ -7,7 +7,7 @@ class X8664UnknownLinuxGnu < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.3.0/x86_64-unknown-linux-gnu-aarch64-darwin.tar.gz"

--- a/x86_64-unknown-linux-musl.rb
+++ b/x86_64-unknown-linux-musl.rb
@@ -7,7 +7,7 @@ class X8664UnknownLinuxMusl < Formula
   depends_on "bdw-gc"
   depends_on "guile"
   depends_on "zstd"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   if Hardware::CPU.arm?
     url "https://github.com/messense/homebrew-macos-cross-toolchains/releases/download/v13.3.0/x86_64-unknown-linux-musl-aarch64-darwin.tar.gz"


### PR DESCRIPTION
Since `python@3.13` is now the default when the formula aliases `python` or `python3` are used:
https://formulae.brew.sh/formula/python@3.13

As such, many other formulae are already using `python@3.13`, so updating to it for this project reduces the chance users will end up having to have two different Python versions installed.

`crosstool-ng` has already updated to `python@3.13` so should be compatible with Python 3.13:
https://github.com/Homebrew/homebrew-core/pull/193960