### PR TITLE
compile for older kernel target

### DIFF
--- a/armv7-unknown-linux-gnueabihf/.config
+++ b/armv7-unknown-linux-gnueabihf/.config
@@ -317,7 +317,7 @@ CT_LINUX_PATCH_ORDER="global"
 CT_LINUX_V_3_4=y
 # CT_LINUX_V_3_2 is not set
 # CT_LINUX_V_2_6_32 is not set
-CT_LINUX_VERSION="3.2.0"
+CT_LINUX_VERSION="3.4.0"
 CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})"
 CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"

--- a/armv7-unknown-linux-gnueabihf/.config
+++ b/armv7-unknown-linux-gnueabihf/.config
@@ -287,7 +287,7 @@ CT_LINUX_PATCH_ORDER="global"
 # CT_LINUX_V_5_13 is not set
 # CT_LINUX_V_5_12 is not set
 # CT_LINUX_V_5_11 is not set
-CT_LINUX_V_5_10=y
+# CT_LINUX_V_5_10 is not set
 # CT_LINUX_V_5_9 is not set
 # CT_LINUX_V_5_8 is not set
 # CT_LINUX_V_5_7 is not set
@@ -314,10 +314,10 @@ CT_LINUX_V_5_10=y
 # CT_LINUX_V_3_13 is not set
 # CT_LINUX_V_3_12 is not set
 # CT_LINUX_V_3_10 is not set
-# CT_LINUX_V_3_4 is not set
+CT_LINUX_V_3_4=y
 # CT_LINUX_V_3_2 is not set
 # CT_LINUX_V_2_6_32 is not set
-CT_LINUX_VERSION="5.10.222"
+CT_LINUX_VERSION="3.2.0"
 CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})"
 CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"


### PR DESCRIPTION
Compile glibc for older kernel target for better compatibility. Fixes #55. 